### PR TITLE
Modernize and standardize task file syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,12 @@
 - include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Reconfigure the stock syslogd(8) on OpenBSD
-  include: configure-OpenBSD-syslogd.yml
+  import_tasks: configure-OpenBSD-syslogd.yml
   when:
-    - "{{ ansible_os_family == 'OpenBSD' }}"
-    - "{{ 'local' in rsyslog_mode }}"
+    - ansible_os_family == "OpenBSD"
+    - "local" in rsyslog_mode
 
-- include: "install-{{ ansible_os_family }}.yml"
+- import_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Create WorkDirectory
   file:
@@ -24,16 +24,16 @@
     state: directory
 
 - name: Configure as client
-  include: configure-client.yml
-  when: '"client" in rsyslog_mode'
+  import_tasks: configure-client.yml
+  when: "client" in rsyslog_mode
 
 - name: Configure as server
-  include: configure-server.yml
-  when: '"server" in rsyslog_mode'
+  import_tasks: configure-server.yml
+  when: "server" in rsyslog_mode
 
 - name: Configure as local
-  include: configure-local.yml
-  when: '"local" in rsyslog_mode'
+  import_tasks: configure-local.yml
+  when: "local" in rsyslog_mode
 
 - name: Create imfile inputs
   # XXX you cannot validate imfile fragments because they are not a valid


### PR DESCRIPTION
use similar quoting style, and use "import_tasks" instead of the
deprecated "include"